### PR TITLE
comparison of peer names provided via command line should not be case sensitive

### DIFF
--- a/update.c
+++ b/update.c
@@ -838,7 +838,7 @@ void csync_update(const char ** patlist, int patnum, int recursive, int dry_run)
 			int i=0, pnamelen = strlen(t->value);
 
 			while (active_peerlist[i]) {
-				if ( !strncmp(active_peerlist+i, t->value, pnamelen) &&
+				if ( !strncasecmp(active_peerlist+i, t->value, pnamelen) &&
 				     (active_peerlist[i+pnamelen] == ',' || !active_peerlist[i+pnamelen]) )
 					goto found_asactive;
 				while (active_peerlist[i])


### PR DESCRIPTION
peer names provided via the -P command-line parameter are not converted to lowercase and
the comparison is done case-sensitive