### PR TITLE
more and clearer error/debug messages, allow A-Z and -_. in config filenames

### DIFF
--- a/csync2.c
+++ b/csync2.c
@@ -646,9 +646,12 @@ int main(int argc, char ** argv)
 
 		for (i=0; cfgname[i]; i++)
 			if ( !(cfgname[i] >= '0' && cfgname[i] <= '9') &&
-			     !(cfgname[i] >= 'a' && cfgname[i] <= 'z') ) {
+			     !(cfgname[i] >= 'a' && cfgname[i] <= 'z') &&
+					 !(cfgname[i] >= 'A' && cfgname[i] <= 'Z') &&
+					 !(cfgname[i] == '_' || cfgname[i] == '-' || cfgname[i] == '.'  )
+				 ) {
 				(mode == MODE_INETD ? conn_printf : csync_fatal)
-						("Config names are limited to [a-z0-9]+.\n");
+						("Config names are limited to [a-zA-Z0-9_.-]+.\n");
 				return mode != MODE_INETD;
 			}
 
@@ -666,8 +669,8 @@ int main(int argc, char ** argv)
 	if (!csync_database || !csync_database[0] || csync_database[0] == '/')
 		csync_database = db_default_database(csync_database);
 
-	csync_debug(2, "My hostname is %s.\n", myhostname);
-	csync_debug(2, "Database-File: %s\n", csync_database);
+	csync_debug(2, "My hostname is [%s].\n", myhostname);
+	csync_debug(2, "Database-File: [%s]\n", csync_database);
 
 	{
 		const struct csync_group *g;
@@ -943,4 +946,3 @@ found_a_group:;
 	if ( retval >= 0 && csync_error_count == 0 ) return retval;
 	return csync_error_count != 0;
 }
-

--- a/csync2.h
+++ b/csync2.h
@@ -21,7 +21,7 @@
 #ifndef CSYNC2_H
 #define CSYNC2_H 1
 
-#define CSYNC2_VERSION "2.0"
+#define CSYNC2_VERSION "2.01"
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -486,4 +486,3 @@ static inline char *on_cygwin_lowercase(char *s) {
 }
 
 #endif /* CSYNC2_H */
-

--- a/daemon.c
+++ b/daemon.c
@@ -219,8 +219,8 @@ int csync_file_backup(const char *filepath)
 				snprintf(error_buffer, 1024, "Write error while backing up '%s': %s\n", filename, strerror(errno));
 
 				cmd_error = error_buffer;
-				// TODO verify file disapeared ? 
-				// 
+				// TODO verify file disapeared ?
+				//
 				// return 1;
 			}
 			csync_setBackupFileStatus(backup_filename, bak_dir_len);
@@ -243,7 +243,7 @@ int csync_copy_file(int fd_in, int fd_out)
 			if (rc == -1) {
 				close(fd_in);
 				close(fd_out);
-				//TODO verify return code. 
+				//TODO verify return code.
 				return errno;
 			}
 			write_len += rc;
@@ -356,6 +356,7 @@ int verify_peername(const char *name, address_t *peeraddr)
 	struct addrinfo *result, *rp;
 	int try_mapped_ipv4;
 	int s;
+	char _address[INET6_ADDRSTRLEN];
 
 	/* Obtain address(es) matching host */
 	memset(&hints, 0, sizeof(struct addrinfo));
@@ -367,7 +368,6 @@ int verify_peername(const char *name, address_t *peeraddr)
 		csync_debug(1, "getaddrinfo: %s\n", gai_strerror(s));
 		return 0;
 	}
-
 	try_mapped_ipv4 =
 		af == AF_INET6 &&
 		!memcmp(&peeraddr->sa_in6.sin6_addr,
@@ -378,23 +378,48 @@ int verify_peername(const char *name, address_t *peeraddr)
 
 	for (rp = result; rp != NULL; rp = rp->ai_next) {
 		/* both IPv4 */
-		if (af == AF_INET && rp->ai_family == AF_INET &&
-		    !memcmp(&((struct sockaddr_in*)rp->ai_addr)->sin_addr,
+
+
+		if (af == AF_INET && rp->ai_family == AF_INET){
+			csync_debug(3,"getaddrinfo translates peername [%s] to ip [%s]\n",name,
+				inet_ntop(AF_INET, &((struct sockaddr_in*)rp->ai_addr)->sin_addr,
+					_address,sizeof(_address)) );
+			if (!memcmp(&((struct sockaddr_in*)rp->ai_addr)->sin_addr,
 			    &peeraddr->sa_in.sin_addr, sizeof(struct in_addr)))
-			break;
+					break;
+			else csync_debug(3, "Doesn't match incoming AF_INET [%s]\n",
+				inet_ntop(AF_INET, &peeraddr->sa_in.sin_addr,
+					_address,sizeof(_address)) );
+		}
+
 		/* both IPv6 */
-		if (af == AF_INET6 && rp->ai_family == AF_INET6 &&
-		    !memcmp(&((struct sockaddr_in6*)rp->ai_addr)->sin6_addr,
+		if (af == AF_INET6 && rp->ai_family == AF_INET6) {
+			csync_debug(3,"getaddrinfo translates peername [%s] to ip [%s]\n",name,
+				inet_ntop(AF_INET6, &((struct sockaddr_in*)rp->ai_addr)->sin_addr,
+					_address,sizeof(_address)) );
+		  if (!memcmp(&((struct sockaddr_in6*)rp->ai_addr)->sin6_addr,
 			    &peeraddr->sa_in6.sin6_addr, sizeof(struct in6_addr)))
-			break;
+					break;
+			else csync_debug(3, "Doesn't match incoming AF_INET6 [%s]\n",
+				inet_ntop(AF_INET6, &peeraddr->sa_in6.sin6_addr,
+					_address,sizeof(_address)) );
+     }
 		/* peeraddr IPv6, but actually ::ffff:I.P.v.4,
 		 * and forward lookup returned IPv4 only */
 		if (af == AF_INET6 && rp->ai_family == AF_INET &&
-		    try_mapped_ipv4 &&
-		    !memcmp(&((struct sockaddr_in*)rp->ai_addr)->sin_addr,
+		    try_mapped_ipv4) {
+				csync_debug(3,"getaddrinfo translates peername [%s] to ip [%s]\n",name,
+						inet_ntop(AF_INET, &((struct sockaddr_in*)rp->ai_addr)->sin_addr,
+							_address,sizeof(_address)) );
+				if (!memcmp(&((struct sockaddr_in*)rp->ai_addr)->sin_addr,
 			    (unsigned char*)&peeraddr->sa_in6.sin6_addr + 12,
 			    sizeof(struct in_addr)))
-			break;
+					break;
+					else csync_debug(3, "Doesn't match incoming AF_INET6 [%s]\n",
+						inet_ntop(AF_INET6, &peeraddr->sa_in6.sin6_addr,
+							_address,sizeof(_address)) );
+		}
+
 	}
 	freeaddrinfo(result);
 	if (rp != NULL) /* memcmp found a match */
@@ -734,6 +759,7 @@ void csync_daemon_session()
 			if (verify_peername(tag[1], &peername)) {
 				peer = strdup(tag[1]);
 			} else {
+				csync_debug(3, "Peername [%s] forward ipnrs don't match incoming ipnr\n", peername,tag[1]);
 				peer = NULL;
 				cmd_error = conn_response(CR_ERR_IDENTIFICATION_FAILED);
 				break;

--- a/update.c
+++ b/update.c
@@ -53,7 +53,7 @@ enum connection_response read_conn_status(const char *file, const char *host)
 		csync_debug(2, "While syncing file %s:\n", file);
 	else
 		file = "<no file>";
-	csync_debug(3, "response from peer(%s): %s [%u] <- %s", file, host, conn_status, line);
+	csync_debug(3, "response from peer(%s): [%s] [%u] <- %s", file, host, conn_status, line);
 	return conn_status;
 }
 
@@ -72,7 +72,7 @@ int connect_to_host(const char *peername)
 		}
 	}
 
-	csync_debug(1, "Connecting to host %s (%s) ...\n",
+	csync_debug(1, "Connecting to host [%s] (%s) ...\n",
 			peername, use_ssl ? "SSL" : "PLAIN");
 
 	if ( conn_open(peername) ) return -1;
@@ -366,7 +366,7 @@ auto_resolve_entry_point:
 			csync_debug(1, "File is already up to date on peer.\n");
 			if ( dry_run ) {
 				printf("?S: %-15s %s\n", peername, filename);
-				// DS also skip on dry_run 
+				// DS also skip on dry_run
 				// return;
 			}
 			goto skip_action;
@@ -636,7 +636,7 @@ enum connection_response conn_hello(struct update_context *c, struct textlist *t
 {
 	enum connection_response r = CR_OK;
 	if ( !c->current_name || strcmp(c->current_name, t->value2) ) {
-		csync_debug(3, "Dirty item %s %s %d\n", t->value, t->value2, t->intvalue); 
+		csync_debug(3, "Dirty item %s %s %d\n", t->value, t->value2, t->intvalue);
 		conn_printf("HELLO %s\n", url_encode(t->value2));
 		r = read_conn_status(t->value, c->peername);
 		if (!is_ok_response(r))
@@ -1150,7 +1150,7 @@ void csync_remove_old()
 		const struct csync_group *g = 0;
 		const struct csync_group_host *h;
 
-		const char *filename = url_decode(SQL_V(0)); 
+		const char *filename = url_decode(SQL_V(0));
 
 		while ((g=csync_find_next(g, filename)) != 0) {
 			if (!strcmp(g->myname, SQL_V(1)))
@@ -1186,4 +1186,3 @@ this_dirty_record_is_ok:
 	}
 	textlist_free(tl);
 }
-


### PR DESCRIPTION
I had quite some trouble figuring out what was wrong with my csync2 setup using NAT, so I added more clear error and debug messages to figure out what;s going on.

The paper.pdf might also be clearer on the host syntax: hostname@interfacename can be misleading, hostname@alternative_NATted_hostname might help people.

The restrictions on the config names lead to hard to read confignames if you have a lot of hierarchic files. Adding A-Z -_. makes things easier to read.

