### PR TITLE
fix build on Alpine Linux ppc64le

### DIFF
--- a/rsync.c
+++ b/rsync.c
@@ -49,7 +49,7 @@
  *
  * @return index of the terminating byte.
  **/
-static size_t strlcpy(char *d, const char *s, size_t bufsize)
+size_t strlcpy(char *d, const char *s, size_t bufsize)
 {
         size_t len = strlen(s);
         size_t ret = len;


### PR DESCRIPTION
Build is failing on Alpine ppc64le with error:
rsync.c:52:15: error: static declaration of 'strlcpy' follows non-static declaration
 static size_t strlcpy(char *d, const char *s, size_t bufsize)

Alpine defines strlcpy in /usr/include/string.h (provided by musl libc) as:
size_t strlcpy (char *, const char *, size_t);

Said that, I'm removing the 'static' modifier from strlcpy function
in rsync.c file.