### PR TITLE
Fix so-names for additional libraries

### DIFF
--- a/db_mysql.c
+++ b/db_mysql.c
@@ -53,16 +53,16 @@ static void *dl_handle;
 
 static void db_mysql_dlopen(void)
 {
-	csync_debug(2, "Opening shared library libmysqlclient.so\n");
-	dl_handle = dlopen("libmysqlclient.so", RTLD_LAZY);
+	csync_debug(2, "Opening shared library libmysqlclient.so.18\n");
+	dl_handle = dlopen("libmysqlclient.so.18", RTLD_LAZY);
 	if (dl_handle == NULL) {
 		csync_fatal
-		    ("Could not open libmysqlclient.so: %s\n"
+		    ("Could not open libmysqlclient.so.18: %s\n"
 		     "Please install Mysql client library (libmysqlclient) or use other database (sqlite, postgres)\n",
 		     dlerror());
 	}
 
-	csync_debug(2, "Reading symbols from shared library libmysqlclient.so\n");
+	csync_debug(2, "Reading symbols from shared library libmysqlclient.so.18\n");
 
 	LOOKUP_SYMBOL(dl_handle, mysql_init);
 	LOOKUP_SYMBOL(dl_handle, mysql_real_connect);

--- a/db_postgres.c
+++ b/db_postgres.c
@@ -58,16 +58,16 @@ static void *dl_handle;
 
 static void db_postgres_dlopen(void)
 {
-	csync_debug(2, "Opening shared library libpq.so\n");
+	csync_debug(2, "Opening shared library libpq.so.5\n");
 
-	dl_handle = dlopen("libpq.so", RTLD_LAZY);
+	dl_handle = dlopen("libpq.so.5", RTLD_LAZY);
 	if (dl_handle == NULL) {
 		csync_fatal
-		    ("Could not open libpq.so: %s\n"
+		    ("Could not open libpq.so.5: %s\n"
 		     "Please install postgres client library (libpg) or use other database (sqlite, mysql)\n",
 		     dlerror());
 	}
-	csync_debug(2, "Reading symbols from shared library libpq.so\n");
+	csync_debug(2, "Reading symbols from shared library libpq.so.5\n");
 
 	LOOKUP_SYMBOL(dl_handle, PQconnectdb);
 	LOOKUP_SYMBOL(dl_handle, PQstatus);

--- a/db_sqlite2.c
+++ b/db_sqlite2.c
@@ -54,20 +54,17 @@ static void *dl_handle;
 
 static void db_sqlite_dlopen(void)
 {
-	csync_debug(2, "Opening shared library libsqlite.so\n");
+	csync_debug(2, "Opening shared library libsqlite.so.0\n");
 
-	dl_handle = dlopen("libsqlite.so", RTLD_LAZY);
+	dl_handle = dlopen("libsqlite.so.0", RTLD_LAZY);
 	if (dl_handle == NULL) {
-		csync_debug(1, "Libsqlite.so not found, trying libsqlite.so.0\n");
-		dl_handle = dlopen("libsqlite.so.0", RTLD_LAZY);
-		if (dl_handle == NULL) {
 			csync_fatal
-			    ("Could not open libsqlite.so: %s\n"
+			    ("Could not open libsqlite.so.0: %s\n"
 			     "Please install sqlite client library (libsqlite) or use other database (postgres, mysql)\n",
 			     dlerror());
 		}
 	}
-	csync_debug(2, "Opening shared library libsqlite.so\n");
+	csync_debug(2, "Opening shared library libsqlite.so.0\n");
 
 	LOOKUP_SYMBOL(dl_handle, sqlite_open);
 	LOOKUP_SYMBOL(dl_handle, sqlite_close);


### PR DESCRIPTION
Commit 36e738e fixed the name passed to dlopen for libsqlite3.so.
This patch fixes the names for other libraries as well.