### PR TITLE
Update csync2.spec

### DIFF
--- a/csync2.spec
+++ b/csync2.spec
@@ -23,6 +23,7 @@
 # norootforbuild
 # neededforbuild  openssl openssl-devel
 
+BuildRequires: automake autoconf mysql-devel postgresql-devel byacc flex
 BuildRequires: sqlite-devel sqlite librsync gnutls-devel librsync-devel
 
 Name:         csync2
@@ -82,8 +83,8 @@ fi
 %doc %{_mandir}/man1/csync2.1.gz
 %doc %{_docdir}/csync2/csync2.adoc
 %doc %{_docdir}/csync2/ChangeLog
-%doc %{_docdir}/csync2/README
-%doc %{_docdir}/csync2/AUTHORS
+%doc %{_docdir}/csync2/README.adoc
+%doc %{_docdir}/csync2/AUTHORS.adoc
 %config(noreplace) %{_sysconfdir}/xinetd.d/csync2
 %config(noreplace) %{_sysconfdir}/csync2.cfg
 


### PR DESCRIPTION
To include this packages in the BuildRequires
+ libpq-devel
+ yacc
+ flex
+ automake and autoconf

- Remove README and AUTHORS from rpm spec file

+ Build successful on CentOS 6/7/8 [copr repo](https://copr.fedorainfracloud.org/coprs/rabiny/csync2/build/1120494/)