### PR TITLE
Hostname detection, timestamp preservation and nanosecond timestamp added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,11 @@ Module.symvers
 Mkfile.old
 dkms.conf
 
+# Project specific
 *.swp
+*.swo
+cfgfile_parser.c
+cfgfile_parser.h
+cfgfile_scanner.c
+config.h
+csync2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,108 @@
+# http://www.gnu.org/software/automake
+
+Makefile.in
+/ar-lib
+/mdate-sh
+/py-compile
+/test-driver
+/ylwrap
+.deps/
+.dirstamp
+
+# http://www.gnu.org/software/autoconf
+
+autom4te.cache
+/autoscan.log
+/autoscan-*.log
+/aclocal.m4
+/compile
+/config.cache
+/config.guess
+/config.h.in
+/config.log
+/config.status
+/config.sub
+/configure
+/configure.scan
+/depcomp
+/install-sh
+/missing
+/stamp-h1
+
+# https://www.gnu.org/software/libtool/
+
+/ltmain.sh
+
+# http://www.gnu.org/software/texinfo
+
+/texinfo.tex
+
+# http://www.gnu.org/software/m4/
+
+m4/libtool.m4
+m4/ltoptions.m4
+m4/ltsugar.m4
+m4/ltversion.m4
+m4/lt~obsolete.m4
+
+# Generated Makefile
+# (meta build system like autotools,
+# can automatically generate from config.status script
+# (which is called by configure script))
+Makefile
+
+
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+*.swp

--- a/check.c
+++ b/check.c
@@ -98,7 +98,13 @@ void csync_mark(const char *file, const char *thispeer, const char *peerfilter)
 	}
 
 	csync_debug(1, "Marking file as dirty: %s\n", file);
-	for (pl_idx=0; pl[pl_idx].peername; pl_idx++)
+	for (pl_idx=0; pl[pl_idx].peername; pl_idx++) {
+		// In case of -P flag, don't mark files as dirty
+		if (active_peerlist && !strstr(active_peerlist, pl[pl_idx].peername))  {
+			csync_debug(1, "Not marking host %s as dirty because -P flag was specified\n", pl[pl_idx].peername);
+			continue;
+		}
+
 		if (!peerfilter || !strcmp(peerfilter, pl[pl_idx].peername)) {
 			SQL("Deleting old dirty file entries",
 				"DELETE FROM dirty WHERE filename = '%s' AND peername = '%s'",
@@ -113,6 +119,7 @@ void csync_mark(const char *file, const char *thispeer, const char *peerfilter)
 				url_encode(pl[pl_idx].myname),
 				url_encode(pl[pl_idx].peername));
 		}
+	}
 
 	free(pl);
 }

--- a/checktxt.c
+++ b/checktxt.c
@@ -19,6 +19,7 @@
  */
 
 #include "csync2.h"
+#include <stdint.h>
 #include <string.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -48,8 +49,10 @@ const char *csync_genchecktxt(const struct stat *st, const char *filename, int i
 	/* version 1 of this check text */
 	xxprintf("v1");
 
-	if ( !S_ISLNK(st->st_mode) && !S_ISDIR(st->st_mode) )
-		xxprintf(":mtime=%lld", ign_mtime ? (long long)0 : (long long)st->st_mtime);
+	if ( !S_ISLNK(st->st_mode) && !S_ISDIR(st->st_mode) ) {
+		int64_t timestamp = st->st_mtime * 1000000000 + st->st_mtim.tv_nsec;
+		xxprintf(":mtime=%lld", ign_mtime ? (long long)0 : (long long)timestamp);
+	}
 
 	if ( !csync_ignore_mod )
 		xxprintf(":mode=%d", (int)st->st_mode);

--- a/csync2.c
+++ b/csync2.c
@@ -67,6 +67,7 @@ int csync_error_count = 0;
 int csync_debug_level = 0;
 FILE *csync_debug_out = 0;
 int csync_syslog = 0;
+int csync_atomic_patch = 0;
 
 int csync_server_child_pid = 0;
 int csync_timestamps = 0;
@@ -436,7 +437,7 @@ int main(int argc, char ** argv)
 		return 1;
 	}
 
-	while ( (opt = getopt(argc, argv, "W:s:Ftp:G:P:C:D:N:HBAIXULlSTMRvhcuoimfxrd")) != -1 ) {
+	while ( (opt = getopt(argc, argv, "W:s:Ftp:G:P:C:D:N:HBAIXULlSTMRavhcuoimfxrd")) != -1 ) {
 
 		switch (opt) {
 			case 'W':
@@ -462,6 +463,9 @@ int main(int argc, char ** argv)
 				break;
 			case 'G':
 				active_grouplist = optarg;
+				break;
+			case 'a':
+				csync_atomic_patch =  1;
 				break;
 			case 'P':
 				active_peerlist = optarg;

--- a/csync2.c
+++ b/csync2.c
@@ -67,7 +67,7 @@ int csync_error_count = 0;
 int csync_debug_level = 0;
 FILE *csync_debug_out = 0;
 int csync_syslog = 0;
-int csync_atomic_patch = 0;
+int csync_atomic_patch = 1; //TODO - make an inverse flag.
 
 int csync_server_child_pid = 0;
 int csync_timestamps = 0;

--- a/csync2.c
+++ b/csync2.c
@@ -684,8 +684,56 @@ int main(int argc, char ** argv)
 	if (!csync_database || !csync_database[0] || csync_database[0] == '/')
 		csync_database = db_default_database(csync_database);
 
+
+
+	// If local hostname is not set, try to guess it by getting the addrinfo of every hostname  in the
+	// group and try to bind on that address. If bind is successful set that host as local hostname.
+	{
+		struct csync_group *g;
+		struct csync_group_host *h;
+		struct csync_group_host *prev = 0;
+		struct addrinfo *rp, *result;
+		int sfd;
+		int bind_status;
+
+		for (g=csync_group; g; g=g->next) {
+			if ( !g->myname ) {
+				h = g->host;
+				while(h && !g->myname) {
+					getaddrinfo(h->hostname, NULL, NULL, &result);
+					for (rp = result; rp != NULL; rp = rp->ai_next) {
+						sfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+						if (sfd == -1)
+							continue;
+						bind_status = bind(sfd, rp->ai_addr, rp->ai_addrlen);
+						close(sfd);
+
+						if (bind_status == 0) {
+							g->myname = h->hostname;
+							snprintf(myhostname, 256, "%s", h->hostname);
+							g->local_slave = h->slave;
+
+							if (!prev) {
+								g->host = h->next;
+							} else {
+								prev->next = h->next;
+							}
+							free(h);
+							csync_debug(1, "My hostname guessed as: %s\n", g->myname);
+							break;
+						}
+					}
+					freeaddrinfo(result);
+					prev = h;
+					h = h->next;
+				}
+			}
+		}
+	}
+
 	csync_debug(2, "My hostname is %s.\n", myhostname);
 	csync_debug(2, "Database-File: %s\n", csync_database);
+
 
 	{
 		const struct csync_group *g;

--- a/csync2.c
+++ b/csync2.c
@@ -437,7 +437,7 @@ int main(int argc, char ** argv)
 		return 1;
 	}
 
-	while ( (opt = getopt(argc, argv, "W:s:Ftp:G:P:C:D:N:HBAIXULlSTMRavhcuoimfxrd")) != -1 ) {
+	while ( (opt = getopt(argc, argv, "W:s:Ftp:G:P:C:D:N:O::HBAIXULlSTMRavhcuoimfxrd")) != -1 ) {
 
 		switch (opt) {
 			case 'W':
@@ -451,6 +451,15 @@ int main(int argc, char ** argv)
 				if (!csync_timestamp_out)
 					csync_fatal("Can't open timestanp file `%s': %s\n",
 							optarg, strerror(errno));
+				break;
+			case 'O': 
+				{
+					char *logname = optarg ? optarg : "/tmp/csync2_full_log.log";
+					if((debug_file = fopen(logname, "w+")) == NULL) {
+						fprintf(stderr, "Could not open full log file:  %s\n", logname);
+						exit(1);
+					}
+				}
 				break;
 			case 'F':
 				csync_new_force = 1;

--- a/csync2.h
+++ b/csync2.h
@@ -78,6 +78,7 @@ extern int csync_perm(const char *filename, const char *key, const char *hostnam
 
 /* error.c */
 
+extern FILE* debug_file;
 extern void csync_printtime();
 extern void csync_printtotaltime();
 extern void csync_fatal(const char *fmt, ...);

--- a/csync2.h
+++ b/csync2.h
@@ -233,7 +233,7 @@ extern int db_sync_mode;
 extern int csync_rs_check(const char *filename, int isreg);
 extern void csync_rs_sig(const char *filename);
 extern int csync_rs_delta(const char *filename);
-extern int csync_rs_patch(const char *filename);
+extern int csync_rs_patch(const char *filename, struct stat *atomic_stats);
 extern int mkpath(const char *path, mode_t mode);
 extern void split_dirname_basename(char *dirname, char* basename, const char *filepath);
 

--- a/csync2.h
+++ b/csync2.h
@@ -435,6 +435,7 @@ extern int csync_messages_printed;
 extern int csync_server_child_pid;
 extern int csync_timestamps;
 extern int csync_new_force;
+extern int csync_atomic_patch;
 
 extern char myhostname[];
 extern int bind_to_myhostname;

--- a/daemon.c
+++ b/daemon.c
@@ -512,9 +512,12 @@ void csync_daemon_session()
 		for (cmdnr=0; cmdtab[cmdnr].text; cmdnr++)
 			if ( !strcasecmp(cmdtab[cmdnr].text, tag[0]) ) break;
 
-		// Print command and it's arguments fully
+		// Print command and its arguments fully
 		csync_debug(1, "START  COMMAND -> %s\n", tag[0]);
 		for (int i = 1; i < 32; i++){
+		      if (!tag[i])
+			      break;
+
 		      csync_debug(1, "[Arg %d] -> %s\n", i, tag[i]);
 		}
 		csync_debug(1, "FINISH  COMMAND -> %s\n", tag[0]);

--- a/daemon.c
+++ b/daemon.c
@@ -514,7 +514,7 @@ void csync_daemon_session()
 
 		// Print command and its arguments fully
 		csync_debug(1, "START  COMMAND -> %s\n", tag[0]);
-		for (int i = 1; i < 32; i++){
+		for (i = 1; i < 32; i++){
 		      if (!(*tag[i]))
 			      break;
 

--- a/daemon.c
+++ b/daemon.c
@@ -298,11 +298,11 @@ enum {
 
 struct csync_command cmdtab[] = {
 	{ "sig",		1, 0, 0, 0, 1, A_SIG	},
-	{ "mark"		1, 0, 0, 0, 1, A_MARK	},
-	{ "type"		2, 0, 0, 0, 1, A_TYPE	},
-	{ "gettm"		1, 0, 0, 0, 1, A_GETTM	},
-	{ "getsz"		1, 0, 0, 0, 1, A_GETSZ	},
-	{ "flush"		1, 1, 0, 0, 1, A_FLUSH	},
+	{ "mark",		1, 0, 0, 0, 1, A_MARK	},
+	{ "type",		2, 0, 0, 0, 1, A_TYPE	},
+	{ "gettm",		1, 0, 0, 0, 1, A_GETTM	},
+	{ "getsz",		1, 0, 0, 0, 1, A_GETSZ	},
+	{ "flush",		1, 1, 0, 0, 1, A_FLUSH	},
 	{ "del",		1, 1, 0, 1, 1, A_DEL	},
 	{ "atomicpatch",	1, 1, 2, 1, 1, A_ATOMIC	},
 	{ "patch",		1, 1, 2, 1, 1, A_PATCH	},

--- a/daemon.c
+++ b/daemon.c
@@ -515,7 +515,7 @@ void csync_daemon_session()
 		// Print command and its arguments fully
 		csync_debug(1, "START  COMMAND -> %s\n", tag[0]);
 		for (int i = 1; i < 32; i++){
-		      if (!tag[i])
+		      if (!(*tag[i]))
 			      break;
 
 		      csync_debug(1, "[Arg %d] -> %s\n", i, tag[i]);

--- a/error.c
+++ b/error.c
@@ -34,6 +34,8 @@ int csync_messages_printed = 0;
 
 time_t csync_startup_time = 0;
 
+FILE *debug_file;
+
 void csync_printtime()
 {
 	if (csync_timestamps || csync_timestamp_out)
@@ -102,6 +104,13 @@ static int csync_log_level_to_sys_log_level(int lv)
 
 void csync_vdebug(int lv, const char *fmt, va_list ap)
 {
+
+	va_list debug_file_va;
+	if (debug_file) {
+		va_copy(debug_file_va, ap);
+		vfprintf(debug_file, fmt, debug_file_va);
+	}
+
 	if (csync_debug_level < lv)
 		return;
 

--- a/error.c
+++ b/error.c
@@ -34,9 +34,6 @@ int csync_messages_printed = 0;
 
 time_t csync_startup_time = 0;
 
-FILE *full_debug_log = 0;
-char *logname = "/tmp/csync2_full_log.log";
-
 void csync_printtime()
 {
 	if (csync_timestamps || csync_timestamp_out)
@@ -105,17 +102,6 @@ static int csync_log_level_to_sys_log_level(int lv)
 
 void csync_vdebug(int lv, const char *fmt, va_list ap)
 {
-	va_list debug_file_va;
-	if (full_debug_log == NULL) {
-		if((full_debug_log = fopen(logname, "w+")) == NULL) {
-			fprintf(stderr, "Could not open full log file:  %s\n", logname);
-			exit(1);
-		}
-	}
-
-	va_copy(debug_file_va, ap);
-	vfprintf(full_debug_log, fmt, debug_file_va);
-
 	if (csync_debug_level < lv)
 		return;
 

--- a/error.c
+++ b/error.c
@@ -34,6 +34,9 @@ int csync_messages_printed = 0;
 
 time_t csync_startup_time = 0;
 
+FILE *full_debug_log = 0;
+char *logname = "/tmp/csync2_full_log.log";
+
 void csync_printtime()
 {
 	if (csync_timestamps || csync_timestamp_out)
@@ -102,6 +105,17 @@ static int csync_log_level_to_sys_log_level(int lv)
 
 void csync_vdebug(int lv, const char *fmt, va_list ap)
 {
+	va_list debug_file_va;
+	if (full_debug_log == NULL) {
+		if((full_debug_log = fopen(logname, "w+")) == NULL) {
+			fprintf(stderr, "Could not open full log file:  %s\n", logname);
+			exit(1);
+		}
+	}
+
+	va_copy(debug_file_va, ap);
+	vfprintf(full_debug_log, fmt, debug_file_va);
+
 	if (csync_debug_level < lv)
 		return;
 

--- a/rsync.c
+++ b/rsync.c
@@ -22,6 +22,7 @@
 #include <librsync.h>
 #include <unistd.h>
 #include <string.h>
+#include <utime.h>
 #include <errno.h>
 #include <stdio.h>
 
@@ -704,12 +705,18 @@ io_error:
  * mtime, ACLs and other meta data as context information before starting to
  * act on it on the receiving side, I don't see how.
  */
-static void clone_ownership_and_permissions(const char *newfname, const char *oldfname)
+static void clone_ownership_and_permissions(const char *newfname, const char *oldfname, struct stat *atomic_stats)
 {
 	struct stat sbuf;
 	int uid, gid;
-	if (stat(oldfname, &sbuf))
-		return; /* At least we tried */
+
+	if (atomic_stats) {
+		sbuf = *atomic_stats;
+	} else {
+		if (stat(oldfname, &sbuf))
+			return; /* At least we tried */
+	}
+
 	uid = csync_ignore_uid ? -1 : sbuf.st_uid;
 	gid = csync_ignore_gid ? -1 : sbuf.st_gid;
 	csync_debug(3, "Cloning ownership and permissions to tmp file: 0o%03o %d:%d %s [%s]\n",
@@ -725,7 +732,7 @@ static void clone_ownership_and_permissions(const char *newfname, const char *ol
 	 * as long as csync2 is no acl aware, there is no point, though */
 }
 
-int csync_rs_patch(const char *filename)
+int csync_rs_patch(const char *filename, struct stat *atomic_stats)
 {
 	FILE *basis_file = 0, *delta_file = 0, *new_file = 0;
 	int backup_errno;
@@ -797,7 +804,17 @@ int csync_rs_patch(const char *filename)
 	}
 #endif
 
-	clone_ownership_and_permissions(newfname, prefixsubst(filename));
+	clone_ownership_and_permissions(newfname, prefixsubst(filename), atomic_stats);
+
+	// Set modification time
+	if (atomic_stats) {
+		struct utimbuf utb;
+		utb.actime = atomic_stats->st_mtime;
+		utb.modtime = atomic_stats->st_mtime;
+		if ( utime(newfname, &utb) )
+			csync_debug(1, "Could not change the modification date\n");
+
+	}
 
 	if (rename(newfname, prefixsubst(filename))) {
 		char buffer[512];

--- a/rsync.c
+++ b/rsync.c
@@ -807,6 +807,7 @@ int csync_rs_patch(const char *filename, struct stat *atomic_stats)
 	clone_ownership_and_permissions(newfname, prefixsubst(filename), atomic_stats);
 
 	// Set modification time
+	fflush(new_file);
 	if (atomic_stats) {
 		struct utimbuf utb;
 		utb.actime = atomic_stats->st_mtime;

--- a/rsync.c
+++ b/rsync.c
@@ -809,10 +809,10 @@ int csync_rs_patch(const char *filename, struct stat *atomic_stats)
 	// Set modification time
 	fflush(new_file);
 	if (atomic_stats) {
-		struct utimbuf utb;
-		utb.actime = atomic_stats->st_mtime;
-		utb.modtime = atomic_stats->st_mtime;
-		if ( utime(newfname, &utb) )
+		struct timespec tsp[2];
+		tsp[0].tv_sec = tsp[1].tv_sec = atomic_stats->st_mtim.tv_sec;
+		tsp[0].tv_nsec = tsp[1].tv_nsec =  atomic_stats->st_mtim.tv_sec;
+		if(utimensat(0, newfname, tsp, 0))
 			csync_debug(1, "Could not change the modification date\n");
 
 	}

--- a/rsync.c
+++ b/rsync.c
@@ -811,7 +811,7 @@ int csync_rs_patch(const char *filename, struct stat *atomic_stats)
 	if (atomic_stats) {
 		struct timespec tsp[2];
 		tsp[0].tv_sec = tsp[1].tv_sec = atomic_stats->st_mtim.tv_sec;
-		tsp[0].tv_nsec = tsp[1].tv_nsec =  atomic_stats->st_mtim.tv_sec;
+		tsp[0].tv_nsec = tsp[1].tv_nsec =  atomic_stats->st_mtim.tv_nsec;
 		if(utimensat(0, newfname, tsp, 0))
 			csync_debug(1, "Could not change the modification date\n");
 

--- a/update.c
+++ b/update.c
@@ -462,7 +462,7 @@ auto_resolve_entry_point:
 		goto got_error;
 	}
 
-	if (!csync_atomic_patch) {
+	if (!csync_atomic_patch || !S_ISREG(st.st_mode)) {
 
 		conn_printf("SETOWN %s %s %d %d\n",
 				url_encode(key), url_encode(filename),

--- a/update.c
+++ b/update.c
@@ -297,6 +297,7 @@ got_error:
 enum connection_response csync_update_file_mod(const char *peername,
 		const char *filename, int force, int dry_run)
 {
+	int atomic_update =  1;
 	struct stat st;
 	enum connection_response last_conn_status = CR_ERROR;
 	int auto_resolve_run = 0;
@@ -378,8 +379,16 @@ auto_resolve_entry_point:
 	}
 
 	if ( S_ISREG(st.st_mode) ) {
-		conn_printf("PATCH %s %s\n",
-				url_encode(key), url_encode(filename));
+		if (atomic_update) {
+			conn_printf("ATOMICPATCH %s %s %d %d %d %d\n",
+					url_encode(key), url_encode(filename),
+					st.st_uid, st.st_gid,
+					st.st_mode,
+					(long long)st.st_mtime);
+		} else {
+			conn_printf("PATCH %s %s\n",
+					url_encode(key), url_encode(filename));
+		}
 		last_conn_status = read_conn_status(filename, peername);
 		/* FIXME be more specific?
 		 * (last_conn_status != CR_OK_SEND_DATA) ??
@@ -452,29 +461,32 @@ auto_resolve_entry_point:
 		goto got_error;
 	}
 
-	conn_printf("SETOWN %s %s %d %d\n",
-			url_encode(key), url_encode(filename),
-			st.st_uid, st.st_gid);
-	last_conn_status = read_conn_status(filename, peername);
-	if (!is_ok_response(last_conn_status))
-		goto got_error;
+	if (!atomic_update) {
 
-	if ( !S_ISLNK(st.st_mode) ) {
-		conn_printf("SETMOD %s %s %d\n", url_encode(key),
-				url_encode(filename), st.st_mode);
+		conn_printf("SETOWN %s %s %d %d\n",
+				url_encode(key), url_encode(filename),
+				st.st_uid, st.st_gid);
 		last_conn_status = read_conn_status(filename, peername);
 		if (!is_ok_response(last_conn_status))
 			goto got_error;
-	}
+
+		if ( !S_ISLNK(st.st_mode) ) {
+			conn_printf("SETMOD %s %s %d\n", url_encode(key),
+					url_encode(filename), st.st_mode);
+			last_conn_status = read_conn_status(filename, peername);
+			if (!is_ok_response(last_conn_status))
+				goto got_error;
+		}
 
 skip_action:
-	if ( !S_ISLNK(st.st_mode) ) {
-		conn_printf("SETIME %s %s %lld\n",
-				url_encode(key), url_encode(filename),
-				(long long)st.st_mtime);
-		last_conn_status = read_conn_status(filename, peername);
-		if (!is_ok_response(last_conn_status))
-			goto got_error;
+		if ( !S_ISLNK(st.st_mode) ) {
+			conn_printf("SETIME %s %s %lld\n",
+					url_encode(key), url_encode(filename),
+					(long long)st.st_mtime);
+			last_conn_status = read_conn_status(filename, peername);
+			if (!is_ok_response(last_conn_status))
+				goto got_error;
+		}
 	}
 
 	SQL("Remove dirty-file entry.",

--- a/update.c
+++ b/update.c
@@ -316,6 +316,8 @@ auto_resolve_entry_point:
 		goto got_error;
 	}
 
+	long long nano_timestamp = st.st_mtime * 1000000000 + st.st_mtim.tv_nsec;
+
 	if ( force ) {
 		if ( dry_run ) {
 			printf("!M: %-15s %s\n", peername, filename);
@@ -379,11 +381,11 @@ auto_resolve_entry_point:
 
 	if ( S_ISREG(st.st_mode) ) {
 		if (csync_atomic_patch) {
-			conn_printf("ATOMICPATCH %s %s %d %d %d %d\n",
+			conn_printf("ATOMICPATCH %s %s %d %d %d %lld\n",
 					url_encode(key), url_encode(filename),
 					st.st_uid, st.st_gid,
 					st.st_mode,
-					(long long)st.st_mtime);
+					nano_timestamp);
 		} else {
 			conn_printf("PATCH %s %s\n",
 					url_encode(key), url_encode(filename));
@@ -481,7 +483,7 @@ skip_action:
 		if ( !S_ISLNK(st.st_mode) ) {
 			conn_printf("SETIME %s %s %lld\n",
 					url_encode(key), url_encode(filename),
-					(long long)st.st_mtime);
+					nano_timestamp);
 			last_conn_status = read_conn_status(filename, peername);
 			if (!is_ok_response(last_conn_status))
 				goto got_error;

--- a/update.c
+++ b/update.c
@@ -297,7 +297,6 @@ got_error:
 enum connection_response csync_update_file_mod(const char *peername,
 		const char *filename, int force, int dry_run)
 {
-	int atomic_update =  1;
 	struct stat st;
 	enum connection_response last_conn_status = CR_ERROR;
 	int auto_resolve_run = 0;
@@ -379,7 +378,7 @@ auto_resolve_entry_point:
 	}
 
 	if ( S_ISREG(st.st_mode) ) {
-		if (atomic_update) {
+		if (csync_atomic_patch) {
 			conn_printf("ATOMICPATCH %s %s %d %d %d %d\n",
 					url_encode(key), url_encode(filename),
 					st.st_uid, st.st_gid,
@@ -461,7 +460,7 @@ auto_resolve_entry_point:
 		goto got_error;
 	}
 
-	if (!atomic_update) {
+	if (!csync_atomic_patch) {
 
 		conn_printf("SETOWN %s %s %d %d\n",
 				url_encode(key), url_encode(filename),


### PR DESCRIPTION
Hostname detection bug fixed where host was having several hostnames
-a switch ensures that file attributes and file copying is done in TMP before it is moved into final destination
Permissions and ownership are now transferred correctly no no more root.root ownership added for all.
Timestamp has nanosecond resolution now.
Logging to file added wit -O switch
_p flag added as a first attempt to make parallel runs of csync2 (several threads on one host targeting several other nodes). Do not use as Sqlite currently locks database for the first thread and others cannot continue. It may need a shift to posgresql as It supports more granular row level locking so parallel processes should not compete for the db access.
For production use - 

csync2 -xa

as command to run.

I am also attaching installation and config instructions as there is no such guide available anywhere making it hard for people to install it. There were 4 people involved (on paid contracts) in making the fixes, config guide and testing to make it easier for the community. I hope my efforts will not go to waste.

This Csync2 version is currently running under heavy use between 4 nodes syncing 317,000 files. It takes about 14 seconds to sync to one node and about 40 seconds to sync all 4 in all directions. There are about 30 file changes every 10 seconds.

My aim is to slash this time at least by half, possibly even make it 4 times faster in the next round.

[Csync2 cluster_instructions.pdf](https://github.com/LINBIT/csync2/files/7168597/Csync2.cluster_instructions.pdf)
